### PR TITLE
Fix "tar1090" display

### DIFF
--- a/install-czadsb.sh
+++ b/install-czadsb.sh
@@ -267,15 +267,16 @@ function info_ctl(){
 # Funkce zobrazi stav vybranych sluzeb
 function info_components(){
     printf "┌ Komponenty / sluzby ─────── Po startu ──── Prednastaveni ── Status ──────┐\n"
-    info_ctl "dump1090"    ; IS_DUMP=${IS_CTL}
-    info_ctl "tar1090"     ; IS_DUMP=${IS_CTL}
-    info_ctl "adsbfwd"     ; IS_ADSB=${IS_CTL}
-    info_ctl "mlat-client" ; IS_MLAT=${IS_CTL}
-    info_ctl "fr24feed"    ; IS_FEED=${IS_CTL}
-    info_ctl "piaware"     ; IS_PIAW=${IS_CTL}
+    info_ctl "dump1090"        ; IS_DUMP=${IS_CTL}
+    info_ctl "tar1090-adsblol" ; IS_DUMP=${IS_CTL}
+    info_ctl "tar1090-adsbx"   ; IS_DUMP=${IS_CTL}
+    info_ctl "adsbfwd"         ; IS_ADSB=${IS_CTL}
+    info_ctl "mlat-client"     ; IS_MLAT=${IS_CTL}
+    info_ctl "fr24feed"        ; IS_FEED=${IS_CTL}
+    info_ctl "piaware"         ; IS_PIAW=${IS_CTL}
     info_ctl "lighttpd"
-    info_ctl "vpn-czadsb"  ; IS_VPNC=${IS_CTL}
-    info_ctl "rpimonitor"  ; IS_RPIM=${IS_CTL}
+    info_ctl "vpn-czadsb"      ; IS_VPNC=${IS_CTL}
+    info_ctl "rpimonitor"      ; IS_RPIM=${IS_CTL}
     if [[ "${OGN}" == "disable" ]] || [[ "${OGN}" == "enable" ]];then
         info_ctl "${OGN_NAME}"
     fi


### PR DESCRIPTION
When using more than one tar1090 project, services are not displayed correctly in the "check status adsb services" section. This is only a quick fix; it should be properly resolved in the info_ctl method.

Here is my solution for tar1090-adsblol and tar1090-adsbx. If you want to add another tar1090-"name" project, it must be defined here in order to display correctly.